### PR TITLE
Load Cursor and One Thread

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <dependency>
             <groupId>org.janelia.saalfeldlab</groupId>
             <artifactId>n5</artifactId>
-            <version>2.5.1</version>
+            <version>3.0.2</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.janelia.saalfeldlab/n5-imglib2 -->
@@ -177,7 +177,7 @@
         <dependency>
             <groupId>org.janelia.saalfeldlab</groupId>
             <artifactId>n5-aws-s3</artifactId>
-            <version>3.2.0</version>
+            <version>4.0.0</version>
         </dependency>
 
 

--- a/src/main/java/org/vcell/vcellfiji/ExportDataRepresentation.java
+++ b/src/main/java/org/vcell/vcellfiji/ExportDataRepresentation.java
@@ -5,10 +5,10 @@ import java.util.HashMap;
 import java.util.Stack;
 
 public class ExportDataRepresentation {
-    public ArrayList<String> globalJobIDs;
+    public Stack<String> globalJobIDs;
     public HashMap<String, FormatExportDataRepresentation> formatData;
 
-    public ExportDataRepresentation(ArrayList<String> globalJobIDs, HashMap<String, FormatExportDataRepresentation> formatData){
+    public ExportDataRepresentation(Stack<String> globalJobIDs, HashMap<String, FormatExportDataRepresentation> formatData){
         this.globalJobIDs = globalJobIDs;
         this.formatData = formatData;
     }

--- a/src/main/java/org/vcell/vcellfiji/ExportDataRepresentation.java
+++ b/src/main/java/org/vcell/vcellfiji/ExportDataRepresentation.java
@@ -1,0 +1,57 @@
+package org.vcell.vcellfiji;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Stack;
+
+public class ExportDataRepresentation {
+    public ArrayList<String> globalJobIDs;
+    public HashMap<String, FormatExportDataRepresentation> formatData;
+
+    public ExportDataRepresentation(ArrayList<String> globalJobIDs, HashMap<String, FormatExportDataRepresentation> formatData){
+        this.globalJobIDs = globalJobIDs;
+        this.formatData = formatData;
+    }
+
+    public static class FormatExportDataRepresentation {
+        public HashMap<String, SimulationExportDataRepresentation> simulationDataMap;
+        public Stack<String> formatJobIDs;
+
+        public FormatExportDataRepresentation(HashMap<String, SimulationExportDataRepresentation> simulationDataMap, Stack<String> formatJobIDs){
+            this.formatJobIDs = formatJobIDs;
+            this.simulationDataMap = simulationDataMap;
+        }
+    }
+
+    public static class SimulationExportDataRepresentation {
+        public String exportDate;
+        public String uri;
+        public String jobID;
+        public String dataID;
+        public String simulationName;
+        public String applicationName;
+        public String biomodelName;
+        public String variables;
+        public String startAndEndTime;
+
+        public ArrayList<String> defaultParameterValues;
+        public ArrayList<String> setParameterValues;
+
+        public SimulationExportDataRepresentation(String exportDate, String uri, String jobID, String dataID, String simulationName,
+                                                  String applicationName, String biomodelName, String variables, String startAndEndTime,
+                                                  ArrayList<String> defaultParameterValues, ArrayList<String> setParameterValues){
+            this.exportDate = exportDate;
+            this.uri = uri;
+            this.jobID = jobID;
+            this.dataID = dataID;
+            this.simulationName = simulationName;
+            this.applicationName = applicationName;
+            this.biomodelName = biomodelName;
+            this.variables = variables;
+            this.startAndEndTime = startAndEndTime;
+            this.defaultParameterValues = defaultParameterValues;
+            this.setParameterValues = setParameterValues;
+        }
+    }
+
+}

--- a/src/main/java/org/vcell/vcellfiji/ExportDataRepresentation.java
+++ b/src/main/java/org/vcell/vcellfiji/ExportDataRepresentation.java
@@ -36,10 +36,12 @@ public class ExportDataRepresentation {
 
         public ArrayList<String> defaultParameterValues;
         public ArrayList<String> setParameterValues;
+        public String savedFileName;
 
         public SimulationExportDataRepresentation(String exportDate, String uri, String jobID, String dataID, String simulationName,
                                                   String applicationName, String biomodelName, String variables, String startAndEndTime,
-                                                  ArrayList<String> defaultParameterValues, ArrayList<String> setParameterValues){
+                                                  ArrayList<String> defaultParameterValues, ArrayList<String> setParameterValues,
+                                                  String savedFileName){
             this.exportDate = exportDate;
             this.uri = uri;
             this.jobID = jobID;

--- a/src/main/java/org/vcell/vcellfiji/N5ImageHandler.java
+++ b/src/main/java/org/vcell/vcellfiji/N5ImageHandler.java
@@ -56,8 +56,14 @@ public class N5ImageHandler implements Command, ActionListener {
     private AmazonS3 s3Client;
     private String bucketName;
     private String s3ObjectKey;
+    public static final String formatName = "N5";
     @Parameter
     private LogService logService;
+
+    private HashMap<DataType, Type> typeHashMap = new HashMap<DataType, Type>() {{
+        put(DataType.UINT8, UnsignedByteType.class);
+    }
+    };
 
     @Override
     public void actionPerformed(ActionEvent e) {
@@ -79,8 +85,8 @@ public class N5ImageHandler implements Command, ActionListener {
                         n5DataSetList = getS3N5DatasetList();
                     } else if (e.getSource() == vGui.mostRecentExport) {
                         ExportDataRepresentation jsonData = getJsonData();
-                        if (jsonData != null && jsonData.formatData.containsKey("N5")) {
-                            ExportDataRepresentation.FormatExportDataRepresentation formatExportDataRepresentation = jsonData.formatData.get("N5");
+                        if (jsonData != null && jsonData.formatData.containsKey(formatName)) {
+                            ExportDataRepresentation.FormatExportDataRepresentation formatExportDataRepresentation = jsonData.formatData.get(formatName);
                             Stack<String> formatJobIDs = formatExportDataRepresentation.formatJobIDs;
                             String jobID = formatJobIDs.isEmpty() ? null : formatJobIDs.peek();
 
@@ -162,7 +168,7 @@ public class N5ImageHandler implements Command, ActionListener {
 
     @Override
     public void run() {
-        this.vGui = new N5ViewerGUI();
+        this.vGui = new N5ViewerGUI(this);
         this.vGui.localFileDialog.addActionListener(this);
         this.vGui.okayButton.addActionListener(this);
 //        this.vGui.exportTableButton.addActionListener(this);

--- a/src/main/java/org/vcell/vcellfiji/N5ImageHandler.java
+++ b/src/main/java/org/vcell/vcellfiji/N5ImageHandler.java
@@ -10,8 +10,6 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.AmazonS3URI;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.internal.LinkedTreeMap;
-import com.google.gson.reflect.TypeToken;
 import ij.ImagePlus;
 import ij.plugin.Duplicator;
 import net.imglib2.cache.img.CachedCellImg;
@@ -93,13 +91,15 @@ public class N5ImageHandler implements Command, ActionListener {
                             ExportDataRepresentation.SimulationExportDataRepresentation lastElement = jobID == null ? null : formatExportDataRepresentation.simulationDataMap.get(jobID);
                             if (lastElement != null) {
                                 String url = lastElement.uri;
+                                String dataset = lastElement.savedFileName;
                                 createS3Client(url);
-                                n5DataSetList = getS3N5DatasetList();
+                                n5DataSetList = new ArrayList<String>(){{
+                                    add(dataset);
+                                }};
                             }
                         }
                     }
-                    publish(n5DataSetList);
-                    return null;
+                    return n5DataSetList;
                 }
 
                 @Override
@@ -108,22 +108,16 @@ public class N5ImageHandler implements Command, ActionListener {
                     enableCriticalButtons(true);
                     try {
                         if (e.getSource() == vGui.localFileDialog && vGui.jFileChooserResult == JFileChooser.APPROVE_OPTION) {
-                            get();
+                            displayN5Results(get());
                         } else if (e.getSource() == vGui.remoteFileSelection.submitS3Info) {
-                            vGui.remoteFileSelection.setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
-                            get();
+                            displayN5Results(get());
                             vGui.remoteFileSelection.dispose();
                         } else if (e.getSource() == vGui.mostRecentExport) {
-                            get();
+                            loadN5Dataset(get().get(0));
                         }
                     } catch (Exception exception) {
                         logService.error(exception);
                     }
-                }
-
-                @Override
-                protected void process(List<ArrayList<String>> chunks) {
-                    displayN5Results(chunks.get(0));
                 }
             };
             n5DatasetListUpdater.execute();

--- a/src/main/java/org/vcell/vcellfiji/N5ImageHandler.java
+++ b/src/main/java/org/vcell/vcellfiji/N5ImageHandler.java
@@ -33,6 +33,7 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -152,6 +153,7 @@ public class N5ImageHandler implements Command, ActionListener {
         // https://stackoverflow.com/questions/16937997/java-swingworker-thread-to-update-main-gui
         // Why swing updating does not work
 
+
     }
 
     private void enableCriticalButtons(boolean enable) {
@@ -160,14 +162,15 @@ public class N5ImageHandler implements Command, ActionListener {
         vGui.localFiles.setEnabled(enable);
         vGui.remoteFiles.setEnabled(enable);
         vGui.mostRecentExport.setEnabled(enable);
+        vGui.exportTableButton.setEnabled(enable);
     }
 
     @Override
     public void run() {
         this.vGui = new N5ViewerGUI();
         this.vGui.localFileDialog.addActionListener(this);
-
         this.vGui.okayButton.addActionListener(this);
+//        this.vGui.exportTableButton.addActionListener(this);
 
         this.vGui.remoteFileSelection.submitS3Info.addActionListener(this);
         this.vGui.mostRecentExport.addActionListener(this);
@@ -335,21 +338,16 @@ public class N5ImageHandler implements Command, ActionListener {
         n5ImageHandler.run();
     }
 
-    public HashMap<String, Object> getJsonData(){
-        try{
-            File jsonFile = new File(System.getProperty("user.home") + "/.vcell", "exportMetaData.json");
-            if (jsonFile.exists() && jsonFile.length() != 0){
-                HashMap<String, Object> jsonHashMap;
-                Gson gson = new GsonBuilder().setPrettyPrinting().create();
-                Type type = new TypeToken<HashMap<String, Object>>() {}.getType();
-                jsonHashMap = gson.fromJson(new FileReader(jsonFile.getAbsolutePath()), type);
-                return jsonHashMap;
-            }
-            return null;
+    public static HashMap<String, Object> getJsonData() throws FileNotFoundException {
+        File jsonFile = new File(System.getProperty("user.home") + "/.vcell", "exportMetaData.json");
+        if (jsonFile.exists() && jsonFile.length() != 0){
+            HashMap<String, Object> jsonHashMap;
+            Gson gson = new GsonBuilder().setPrettyPrinting().create();
+            Type type = new TypeToken<HashMap<String, Object>>() {}.getType();
+            jsonHashMap = gson.fromJson(new FileReader(jsonFile.getAbsolutePath()), type);
+            return jsonHashMap;
         }
-        catch (Exception e){
-            logService.error("Failed to read export metadata JSON:", e);
-            return null;
-        }
+        return null;
+
     }
 }

--- a/src/main/java/org/vcell/vcellfiji/N5ImageHandler.java
+++ b/src/main/java/org/vcell/vcellfiji/N5ImageHandler.java
@@ -188,8 +188,6 @@ public class N5ImageHandler implements Command, ActionListener {
                 };
             }
             return fList;
-        } catch (IOException e) {
-            throw new RuntimeException(e);
         }
     }
 
@@ -236,20 +234,12 @@ public class N5ImageHandler implements Command, ActionListener {
     }
 
     public N5AmazonS3Reader getN5AmazonS3Reader(){
-        try(N5AmazonS3Reader n5AmazonS3Reader = new N5AmazonS3Reader(this.s3Client, this.bucketName, this.s3ObjectKey)){
-            return n5AmazonS3Reader;
-        }
-        catch (IOException e){
-            throw new RuntimeException(e);
-        }
+        return new N5AmazonS3Reader(this.s3Client, this.bucketName, this.s3ObjectKey);
     }
 
     public N5FSReader getN5FSReader(){
-        try (N5FSReader n5FSReader = new N5FSReader(selectedLocalFile.getPath())) {
-            return n5FSReader;
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        return new N5FSReader(selectedLocalFile.getPath());
+
     }
 
     public void loadN5Dataset(String selectedDataset) throws IOException {
@@ -320,9 +310,6 @@ public class N5ImageHandler implements Command, ActionListener {
 
         try(N5AmazonS3Reader n5AmazonS3Reader = new N5AmazonS3Reader(this.s3Client, this.bucketName)) {
             return new ArrayList<>(Arrays.asList(n5AmazonS3Reader.deepListDatasets(this.s3ObjectKey)));
-        }
-        catch (IOException e){
-            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/org/vcell/vcellfiji/N5ImageHandler.java
+++ b/src/main/java/org/vcell/vcellfiji/N5ImageHandler.java
@@ -200,21 +200,21 @@ public class N5ImageHandler implements Command, ActionListener {
         // Theres definitly a better way to do this, I trie using a variable to change the cached cells first parameter type but it didn't seem to work :/
         switch (n5Reader.getDatasetAttributes(selectedDataset).getDataType()){
             case UINT8:
-                return ImageJFunctions.wrap((CachedCellImg<UnsignedByteType, ?>)N5Utils.open(n5Reader, selectedDataset), "");
+                return ImageJFunctions.wrap((CachedCellImg<UnsignedByteType, ?>)N5Utils.open(n5Reader, selectedDataset), selectedDataset);
             case UINT16:
-                return ImageJFunctions.wrap((CachedCellImg<UnsignedShortType, ?>)N5Utils.open(n5Reader, selectedDataset), "");
+                return ImageJFunctions.wrap((CachedCellImg<UnsignedShortType, ?>)N5Utils.open(n5Reader, selectedDataset), selectedDataset);
             case UINT32:
-                return ImageJFunctions.wrap((CachedCellImg<UnsignedIntType, ?>)N5Utils.open(n5Reader, selectedDataset), "");
+                return ImageJFunctions.wrap((CachedCellImg<UnsignedIntType, ?>)N5Utils.open(n5Reader, selectedDataset), selectedDataset);
             case INT8:
-                return ImageJFunctions.wrap((CachedCellImg<ByteType, ?>)N5Utils.open(n5Reader, selectedDataset), "");
+                return ImageJFunctions.wrap((CachedCellImg<ByteType, ?>)N5Utils.open(n5Reader, selectedDataset), selectedDataset);
             case INT16:
-                return ImageJFunctions.wrap((CachedCellImg<ShortType, ?>)N5Utils.open(n5Reader, selectedDataset), "");
+                return ImageJFunctions.wrap((CachedCellImg<ShortType, ?>)N5Utils.open(n5Reader, selectedDataset), selectedDataset);
             case INT32:
-                return ImageJFunctions.wrap((CachedCellImg<IntType, ?>)N5Utils.open(n5Reader, selectedDataset), "");
+                return ImageJFunctions.wrap((CachedCellImg<IntType, ?>)N5Utils.open(n5Reader, selectedDataset), selectedDataset);
             case FLOAT32:
-                return ImageJFunctions.wrap((CachedCellImg<FloatType, ?>)N5Utils.open(n5Reader, selectedDataset), "");
+                return ImageJFunctions.wrap((CachedCellImg<FloatType, ?>)N5Utils.open(n5Reader, selectedDataset), selectedDataset);
             case FLOAT64:
-                return ImageJFunctions.wrap((CachedCellImg<DoubleType, ?>)N5Utils.open(n5Reader, selectedDataset), "");
+                return ImageJFunctions.wrap((CachedCellImg<DoubleType, ?>)N5Utils.open(n5Reader, selectedDataset), selectedDataset);
 //                final ARGBARGBDoubleConverter<ARGBDoubleType> converters = new ARGBARGBDoubleConverter<>();
 //                final CachedCellImg<DoubleType, ?> cachedCellImg = N5Utils.open(n5Reader, selectedDataset);
 //                return ImageJFunctions.showRGB(cachedCellImg, converters, "");

--- a/src/main/java/org/vcell/vcellfiji/UI/N5ExportTable.java
+++ b/src/main/java/org/vcell/vcellfiji/UI/N5ExportTable.java
@@ -6,21 +6,29 @@ import org.vcell.vcellfiji.ExportDataRepresentation;
 import org.vcell.vcellfiji.N5ImageHandler;
 
 import javax.swing.*;
-import javax.swing.table.DefaultTableModel;
+import javax.swing.table.AbstractTableModel;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Stack;
 
 public class N5ExportTable implements ActionListener {
     private JDialog exportTableDialog;
     private JPanel exportTablePanel;
-    private DefaultTableModel exportTableModel;
+    private N5ExportTableModel n5ExportTableModel;
+    private JButton open;
+    private JTable jTable;
     @Parameter
     private LogService logService;
+    private N5ImageHandler n5ImageHandler;
+
+    public N5ExportTable(N5ImageHandler n5ImageHandler){
+        initialize();
+        this.n5ImageHandler = n5ImageHandler;
+    }
     public void updateTableModel(){
         try{
             ExportDataRepresentation jsonData = N5ImageHandler.getJsonData();
@@ -44,64 +52,65 @@ public class N5ExportTable implements ActionListener {
     }
 
     public void initalizeTableData(){
-//        ExportDataRepresentation jsonData = null;
-//        try {
-//            jsonData = N5ImageHandler.getJsonData();
-//            if (jsonData != null){
-//                List<String> set = (ArrayList<String>) jsonData.get("jobIDs");
-//                for (String s : set) {
-//                    addRowFromJson(jsonData, s);
-//                }
-//            }
-//            exportTableModel.fireTableDataChanged();
-//        } catch (FileNotFoundException e) {
-//            throw new RuntimeException(e);
-//        }
+        ExportDataRepresentation jsonData = null;
+        try {
+            jsonData = N5ImageHandler.getJsonData();
+            if (jsonData != null){
+                ExportDataRepresentation.FormatExportDataRepresentation formatExportData = jsonData.formatData.get(N5ImageHandler.formatName);
+                Stack<String> jobStack = formatExportData.formatJobIDs;
+                while (!jobStack.isEmpty()){
+                    n5ExportTableModel.addRowData(formatExportData.simulationDataMap.get(jobStack.pop()));
+                }
+            }
+            n5ExportTableModel.fireTableDataChanged();
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
     }
 
-    public void addRowFromJson(HashMap<String, Object> jsonData, String s){
-        exportTableModel.addRow(new Object[]{""});
+
+    private void initialize(){
+        exportTablePanel = new JPanel();
+
+        n5ExportTableModel = new N5ExportTableModel();
+
+        jTable = new JTable(n5ExportTableModel);
+        JScrollPane jScrollPane = new JScrollPane(jTable);
+
+        jScrollPane.setSize(500, 400);
+        jScrollPane.setPreferredSize(new Dimension(500, 400));
+        jScrollPane.setMinimumSize(new Dimension(500, 400));
+
+        JLabel jLabel = new JLabel("Recent Exports. List is volatile save important export metadata elsewhere.");
+        JButton refresh = new JButton("Refresh List");
+        open = new JButton("Open");
+
+        JPanel topBar = new JPanel();
+        topBar.setLayout(new FlowLayout());
+        refresh.addActionListener(this);
+        open.addActionListener(this);
+        topBar.add(jLabel);
+        topBar.add(open);
+        topBar.add(refresh);
+
+        exportTablePanel.setLayout(new BorderLayout());
+        exportTablePanel.add(topBar, BorderLayout.NORTH);
+        exportTablePanel.add(jScrollPane);
+
+        exportTablePanel.setPreferredSize(new Dimension(800, 500));
+        JOptionPane pane = new JOptionPane(exportTablePanel, JOptionPane.PLAIN_MESSAGE, 0, null, new Object[]{"Close"});
+        exportTableDialog = pane.createDialog("VCell Exports");
+        exportTableDialog.setModal(false);
+        exportTableDialog.setResizable(true);
+        exportTableDialog.setVisible(true);
+
+        initalizeTableData();
     }
+
 
     public void displayExportTable() {
         if (exportTableDialog == null) {
-            exportTablePanel = new JPanel();
-
-            DefaultTableModel defaultTableModel = new DefaultTableModel();
-            defaultTableModel.addColumn("Test");
-            defaultTableModel.addColumn("Test2");
-            Object[] testRow = {"k", "b"};
-            defaultTableModel.addRow(testRow);
-
-            JTable jTable = new JTable(defaultTableModel);
-            JScrollPane jScrollPane = new JScrollPane(jTable);
-
-            jScrollPane.setSize(500, 400);
-            jScrollPane.setPreferredSize(new Dimension(500, 400));
-            jScrollPane.setMinimumSize(new Dimension(500, 400));
-
-            JLabel jLabel = new JLabel("Recent Exports. List is volatile save important export metadata elsewhere.");
-            JButton refresh = new JButton("Refresh List");
-            JButton open = new JButton("Open");
-
-            JPanel topBar = new JPanel();
-            topBar.setLayout(new FlowLayout());
-            refresh.addActionListener(this);
-            open.addActionListener(this);
-            topBar.add(jLabel);
-            topBar.add(open);
-            topBar.add(refresh);
-
-            exportTablePanel.setLayout(new BorderLayout());
-            exportTablePanel.add(topBar, BorderLayout.NORTH);
-            exportTablePanel.add(jScrollPane);
-
-            exportTablePanel.setPreferredSize(new Dimension(800, 500));
-            JOptionPane pane = new JOptionPane(exportTablePanel, JOptionPane.PLAIN_MESSAGE, 0, null, new Object[]{"Close"});
-            exportTableDialog = pane.createDialog("VCell Exports");
-            exportTableDialog.setModal(false);
-            exportTableDialog.setResizable(true);
-            exportTableDialog.setVisible(true);
+            initialize();
         } else {
             exportTableDialog.setVisible(true);
         }
@@ -109,6 +118,79 @@ public class N5ExportTable implements ActionListener {
 
     @Override
     public void actionPerformed(ActionEvent e) {
+        if(e.getSource().equals(open)){
+            int[] selectedRows = jTable.getSelectedRows();
+            for(int row: selectedRows){
+                String uri = n5ExportTableModel.getRowData(row).uri;
+                n5ImageHandler.createS3Client(uri);
+                n5ImageHandler.displayN5Results(n5ImageHandler.getS3N5DatasetList());
+            }
+        }
+    }
 
+    static class N5ExportTableModel extends AbstractTableModel {
+        public final ArrayList<String> headers = new ArrayList<String>(){{
+            add("BM Name");
+            add("App Name");
+            add("Sim Name");
+            add("Time Slice");
+            add("Variables");
+            add("Default Parameters");
+            add("Set Parameters");
+            add("Date Exported");
+        }};
+
+        private final List<ExportDataRepresentation.SimulationExportDataRepresentation> tableData = new ArrayList<>();
+
+        public N5ExportTableModel(){
+        }
+
+        @Override
+        public int getRowCount() {
+            return tableData.size();
+        }
+
+        @Override
+        public int getColumnCount() {
+            return headers.size();
+        }
+
+        @Override
+        public String getColumnName(int column) {
+            return headers.get(column);
+        }
+
+        @Override
+        public Object getValueAt(int rowIndex, int columnIndex) {
+            ExportDataRepresentation.SimulationExportDataRepresentation data = getRowData(rowIndex);
+            if (columnIndex == headers.indexOf("App Name")){
+                return data.applicationName;
+            } else if (columnIndex == headers.indexOf("BM Name")) {
+                return data.biomodelName;
+            } else if (columnIndex == headers.indexOf("Sim Name")) {
+                return data.simulationName;
+            } else if (columnIndex == headers.indexOf("Time Slice")) {
+                return  data.startAndEndTime;
+            } else if (columnIndex == headers.indexOf("Variables")) {
+                return data.variables;
+            } else if (columnIndex == headers.indexOf("Date Exported")) {
+                return data.exportDate;
+            }
+            else if (columnIndex == headers.indexOf("Default Parameters")) {
+                return String.valueOf(data.defaultParameterValues);
+            }
+            else if (columnIndex == headers.indexOf("Set Parameters")) {
+                return String.valueOf(data.setParameterValues);
+            }
+            return null;
+        }
+
+        public ExportDataRepresentation.SimulationExportDataRepresentation getRowData(int rowIndex){
+            return tableData.get(rowIndex);
+        }
+
+        public void addRowData(ExportDataRepresentation.SimulationExportDataRepresentation rowData){
+            tableData.add(rowData);
+        }
     }
 }

--- a/src/main/java/org/vcell/vcellfiji/UI/N5ExportTable.java
+++ b/src/main/java/org/vcell/vcellfiji/UI/N5ExportTable.java
@@ -1,0 +1,114 @@
+package org.vcell.vcellfiji.UI;
+
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.vcell.vcellfiji.ExportDataRepresentation;
+import org.vcell.vcellfiji.N5ImageHandler;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableModel;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class N5ExportTable implements ActionListener {
+    private JDialog exportTableDialog;
+    private JPanel exportTablePanel;
+    private DefaultTableModel exportTableModel;
+    @Parameter
+    private LogService logService;
+    public void updateTableModel(){
+        try{
+            ExportDataRepresentation jsonData = N5ImageHandler.getJsonData();
+//            if (jsonData != null){
+//                List<String> globalJobIDs = jsonData.globalJobIDs;
+//                String lastElement = tableModel.getRowCount() == 0 ? null: tableModel.tableData.get(tableModel.tableData.size() - 1).jobID;
+//                for(int i = globalJobIDs.size() - 1; i > -1; i--){
+//                    // first index is JobID, second is data format
+//                    String[] tokens = globalJobIDs.get(i).split(",");
+//                    if(lastElement != null && lastElement.equals(tokens[0])){
+//                        break;
+//                    }
+//                    addRowFromJson(tokens[0], tokens[1], jsonData);
+//                }
+//            }
+//            tableModel.refreshData();
+        }
+        catch (Exception e){
+            logService.error("Failed Update Export Viewer Table Model:", e);
+        }
+    }
+
+    public void initalizeTableData(){
+//        ExportDataRepresentation jsonData = null;
+//        try {
+//            jsonData = N5ImageHandler.getJsonData();
+//            if (jsonData != null){
+//                List<String> set = (ArrayList<String>) jsonData.get("jobIDs");
+//                for (String s : set) {
+//                    addRowFromJson(jsonData, s);
+//                }
+//            }
+//            exportTableModel.fireTableDataChanged();
+//        } catch (FileNotFoundException e) {
+//            throw new RuntimeException(e);
+//        }
+    }
+
+    public void addRowFromJson(HashMap<String, Object> jsonData, String s){
+        exportTableModel.addRow(new Object[]{""});
+    }
+
+    public void displayExportTable() {
+        if (exportTableDialog == null) {
+            exportTablePanel = new JPanel();
+
+            DefaultTableModel defaultTableModel = new DefaultTableModel();
+            defaultTableModel.addColumn("Test");
+            defaultTableModel.addColumn("Test2");
+            Object[] testRow = {"k", "b"};
+            defaultTableModel.addRow(testRow);
+
+            JTable jTable = new JTable(defaultTableModel);
+            JScrollPane jScrollPane = new JScrollPane(jTable);
+
+            jScrollPane.setSize(500, 400);
+            jScrollPane.setPreferredSize(new Dimension(500, 400));
+            jScrollPane.setMinimumSize(new Dimension(500, 400));
+
+            JLabel jLabel = new JLabel("Recent Exports. List is volatile save important export metadata elsewhere.");
+            JButton refresh = new JButton("Refresh List");
+            JButton open = new JButton("Open");
+
+            JPanel topBar = new JPanel();
+            topBar.setLayout(new FlowLayout());
+            refresh.addActionListener(this);
+            open.addActionListener(this);
+            topBar.add(jLabel);
+            topBar.add(open);
+            topBar.add(refresh);
+
+            exportTablePanel.setLayout(new BorderLayout());
+            exportTablePanel.add(topBar, BorderLayout.NORTH);
+            exportTablePanel.add(jScrollPane);
+
+            exportTablePanel.setPreferredSize(new Dimension(800, 500));
+            JOptionPane pane = new JOptionPane(exportTablePanel, JOptionPane.PLAIN_MESSAGE, 0, null, new Object[]{"Close"});
+            exportTableDialog = pane.createDialog("VCell Exports");
+            exportTableDialog.setModal(false);
+            exportTableDialog.setResizable(true);
+            exportTableDialog.setVisible(true);
+        } else {
+            exportTableDialog.setVisible(true);
+        }
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+
+    }
+}

--- a/src/main/java/org/vcell/vcellfiji/UI/N5ViewerGUI.java
+++ b/src/main/java/org/vcell/vcellfiji/UI/N5ViewerGUI.java
@@ -28,9 +28,7 @@ public class N5ViewerGUI extends JFrame implements ActionListener {
     private JLabel datasetLabel;
     private JLabel openInMemory;
     public int jFileChooserResult;
-    private JDialog exportTableDialog;
-    private JPanel exportTablePanel;
-    private DefaultTableModel exportTableModel;
+    private N5ExportTable n5ExportTable;
 
     public JButton mostRecentExport;
 
@@ -130,6 +128,7 @@ public class N5ViewerGUI extends JFrame implements ActionListener {
         this.remoteFileSelection = new RemoteFileSelection(thisJFrame);
 
 
+        n5ExportTable = new N5ExportTable();
     }
 
     public void updateDatasetList(ArrayList<String> arrayList){
@@ -153,97 +152,12 @@ public class N5ViewerGUI extends JFrame implements ActionListener {
         } else if (e.getSource() == remoteFiles) {
             remoteFileSelection.setVisible(true);
         } else if (e.getSource() == exportTableButton) {
-            displayExportTable();
+            n5ExportTable.displayExportTable();
         }
     }
 
     public void refreshDataList(){
 
-    }
-
-    public void updateTableModel(){
-        try{
-            HashMap<String, Object> jsonData = N5ImageHandler.getJsonData();
-            if (jsonData != null){
-                List<String> set = (ArrayList<String>) jsonData.get("jobIDs");
-                String lastElement = exportTableModel.getRowCount() == 0 ? null: (String) exportTableModel.getValueAt(0,0);
-                for(int i = set.size() - 1; i > -1; i--){
-                    if(lastElement != null && lastElement.equals(set.get(i))){
-                        break;
-                    }
-                    addRowFromJson(jsonData, set.get(i));
-                }
-            }
-            exportTableModel.fireTableDataChanged();
-        }
-        catch (Exception e){
-            throw new RuntimeException(e);
-        }
-    }
-
-    public void initalizeTableData(){
-        HashMap<String, Object> jsonData = null;
-        try {
-            jsonData = N5ImageHandler.getJsonData();
-            if (jsonData != null){
-                List<String> set = (ArrayList<String>) jsonData.get("jobIDs");
-                for (String s : set) {
-                    addRowFromJson(jsonData, s);
-                }
-            }
-            exportTableModel.fireTableDataChanged();
-        } catch (FileNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public void addRowFromJson(HashMap<String, Object> jsonData, String s){
-        exportTableModel.addRow(new Object[]{""});
-    }
-
-    public void displayExportTable(){
-        if (exportTableDialog == null){
-            exportTablePanel = new JPanel();
-
-            DefaultTableModel defaultTableModel = new DefaultTableModel();
-            defaultTableModel.addColumn("Test");
-            defaultTableModel.addColumn("Test2");
-            Object[] testRow = {"k", "b"};
-            defaultTableModel.addRow(testRow);
-
-            JTable jTable = new JTable(defaultTableModel);
-            JScrollPane jScrollPane = new JScrollPane(jTable);
-
-            jScrollPane.setSize(500, 400);
-            jScrollPane.setPreferredSize(new Dimension(500, 400));
-            jScrollPane.setMinimumSize(new Dimension(500, 400));
-
-            JLabel jLabel = new JLabel("Recent Exports. List is volatile save important export metadata elsewhere.");
-            JButton refresh = new JButton("Refresh List");
-            JButton open = new JButton("Open");
-
-            JPanel topBar = new JPanel();
-            topBar.setLayout(new FlowLayout());
-            refresh.addActionListener(this);
-            open.addActionListener(this);
-            topBar.add(jLabel);
-            topBar.add(open);
-            topBar.add(refresh);
-
-            exportTablePanel.setLayout(new BorderLayout());
-            exportTablePanel.add(topBar, BorderLayout.NORTH);
-            exportTablePanel.add(jScrollPane);
-
-            exportTablePanel.setPreferredSize(new Dimension(800, 500));
-            JOptionPane pane = new JOptionPane(exportTablePanel, JOptionPane.PLAIN_MESSAGE, 0, null, new Object[] {"Close"});
-            exportTableDialog = pane.createDialog("VCell Exports");
-            exportTableDialog.setModal(false);
-            exportTableDialog.setResizable(true);
-            exportTableDialog.setVisible(true);
-        }
-        else {
-            exportTableDialog.setVisible(true);
-        }
     }
 
 

--- a/src/main/java/org/vcell/vcellfiji/UI/N5ViewerGUI.java
+++ b/src/main/java/org/vcell/vcellfiji/UI/N5ViewerGUI.java
@@ -34,7 +34,7 @@ public class N5ViewerGUI extends JFrame implements ActionListener {
 
     public RemoteFileSelection remoteFileSelection;
 
-    public N5ViewerGUI() {
+    public N5ViewerGUI(N5ImageHandler n5ImageHandler) {
         thisJFrame = this;
         localFileDialog = new JFileChooser();
         mainPanel = new JPanel();
@@ -128,7 +128,7 @@ public class N5ViewerGUI extends JFrame implements ActionListener {
         this.remoteFileSelection = new RemoteFileSelection(thisJFrame);
 
 
-        n5ExportTable = new N5ExportTable();
+        n5ExportTable = new N5ExportTable(n5ImageHandler);
     }
 
     public void updateDatasetList(ArrayList<String> arrayList){
@@ -155,11 +155,6 @@ public class N5ViewerGUI extends JFrame implements ActionListener {
             n5ExportTable.displayExportTable();
         }
     }
-
-    public void refreshDataList(){
-
-    }
-
 
 }
 

--- a/src/main/java/org/vcell/vcellfiji/UI/N5ViewerGUI.java
+++ b/src/main/java/org/vcell/vcellfiji/UI/N5ViewerGUI.java
@@ -1,10 +1,16 @@
 package org.vcell.vcellfiji.UI;
 
+import org.vcell.vcellfiji.N5ImageHandler;
+
 import javax.swing.*;
+import javax.swing.table.DefaultTableModel;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.io.FileNotFoundException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 
 public class N5ViewerGUI extends JFrame implements ActionListener {
     public JButton localFiles;
@@ -16,11 +22,15 @@ public class N5ViewerGUI extends JFrame implements ActionListener {
     private JScrollPane resultsScrollPane;
     public JButton remoteFiles;
     public JButton okayButton;
+    public JButton exportTableButton;
     public JCheckBox openMemoryCheckBox;
     private JPanel datasetListPanel;
     private JLabel datasetLabel;
     private JLabel openInMemory;
     public int jFileChooserResult;
+    private JDialog exportTableDialog;
+    private JPanel exportTablePanel;
+    private DefaultTableModel exportTableModel;
 
     public JButton mostRecentExport;
 
@@ -41,7 +51,7 @@ public class N5ViewerGUI extends JFrame implements ActionListener {
         mainPanelConstraints.gridy = 0;
         localFiles = new JButton();
         localFiles.setText("Local Files");
-        mainPanel.add(localFiles, mainPanelConstraints);
+//        mainPanel.add(localFiles, mainPanelConstraints);
 
         mainPanelConstraints.gridy = 0;
         mainPanelConstraints.gridx = 1;
@@ -57,12 +67,18 @@ public class N5ViewerGUI extends JFrame implements ActionListener {
 
         mainPanelConstraints.gridy = 0;
         mainPanelConstraints.gridx = 3;
+        exportTableButton = new JButton();
+        exportTableButton.setText("Export Table");
+        mainPanel.add(exportTableButton, mainPanelConstraints);
+
+        mainPanelConstraints.gridy = 0;
+        mainPanelConstraints.gridx = 4;
         openInMemory = new JLabel();
         openInMemory.setText("Open Image in Memory");
         mainPanel.add(openInMemory, mainPanelConstraints);
 
         mainPanelConstraints.gridy = 0;
-        mainPanelConstraints.gridx = 4;
+        mainPanelConstraints.gridx = 5;
         openMemoryCheckBox = new JCheckBox();
         mainPanel.add(openMemoryCheckBox, mainPanelConstraints);
 
@@ -82,7 +98,7 @@ public class N5ViewerGUI extends JFrame implements ActionListener {
         resultsScrollPane = new JScrollPane(datasetList);
         datasetListPanel.add(resultsScrollPane, datasetConstraints);
 
-        mainPanelConstraints.gridwidth = 4;
+        mainPanelConstraints.gridwidth = 5;
         mainPanelConstraints.gridy = 1;
         mainPanelConstraints.ipady = 40;
         mainPanelConstraints.gridx = 0;
@@ -94,7 +110,7 @@ public class N5ViewerGUI extends JFrame implements ActionListener {
         mainPanelConstraints = new GridBagConstraints();
         mainPanelConstraints.gridy = 2;
         mainPanelConstraints.gridx = 0;
-        mainPanelConstraints.gridwidth = 4;
+        mainPanelConstraints.gridwidth = 5;
         okayButton = new JButton();
         okayButton.setText("Open Dataset");
         mainPanel.add(okayButton, mainPanelConstraints);
@@ -103,6 +119,7 @@ public class N5ViewerGUI extends JFrame implements ActionListener {
         localFiles.addActionListener(this);
 
         remoteFiles.addActionListener(this);
+        exportTableButton.addActionListener(this);
 
         // listener for if credentials or endpoint is used
 
@@ -135,7 +152,100 @@ public class N5ViewerGUI extends JFrame implements ActionListener {
             jFileChooserResult = localFileDialog.showOpenDialog(thisJFrame);
         } else if (e.getSource() == remoteFiles) {
             remoteFileSelection.setVisible(true);
+        } else if (e.getSource() == exportTableButton) {
+            displayExportTable();
         }
     }
+
+    public void refreshDataList(){
+
+    }
+
+    public void updateTableModel(){
+        try{
+            HashMap<String, Object> jsonData = N5ImageHandler.getJsonData();
+            if (jsonData != null){
+                List<String> set = (ArrayList<String>) jsonData.get("jobIDs");
+                String lastElement = exportTableModel.getRowCount() == 0 ? null: (String) exportTableModel.getValueAt(0,0);
+                for(int i = set.size() - 1; i > -1; i--){
+                    if(lastElement != null && lastElement.equals(set.get(i))){
+                        break;
+                    }
+                    addRowFromJson(jsonData, set.get(i));
+                }
+            }
+            exportTableModel.fireTableDataChanged();
+        }
+        catch (Exception e){
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void initalizeTableData(){
+        HashMap<String, Object> jsonData = null;
+        try {
+            jsonData = N5ImageHandler.getJsonData();
+            if (jsonData != null){
+                List<String> set = (ArrayList<String>) jsonData.get("jobIDs");
+                for (String s : set) {
+                    addRowFromJson(jsonData, s);
+                }
+            }
+            exportTableModel.fireTableDataChanged();
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void addRowFromJson(HashMap<String, Object> jsonData, String s){
+        exportTableModel.addRow(new Object[]{""});
+    }
+
+    public void displayExportTable(){
+        if (exportTableDialog == null){
+            exportTablePanel = new JPanel();
+
+            DefaultTableModel defaultTableModel = new DefaultTableModel();
+            defaultTableModel.addColumn("Test");
+            defaultTableModel.addColumn("Test2");
+            Object[] testRow = {"k", "b"};
+            defaultTableModel.addRow(testRow);
+
+            JTable jTable = new JTable(defaultTableModel);
+            JScrollPane jScrollPane = new JScrollPane(jTable);
+
+            jScrollPane.setSize(500, 400);
+            jScrollPane.setPreferredSize(new Dimension(500, 400));
+            jScrollPane.setMinimumSize(new Dimension(500, 400));
+
+            JLabel jLabel = new JLabel("Recent Exports. List is volatile save important export metadata elsewhere.");
+            JButton refresh = new JButton("Refresh List");
+            JButton open = new JButton("Open");
+
+            JPanel topBar = new JPanel();
+            topBar.setLayout(new FlowLayout());
+            refresh.addActionListener(this);
+            open.addActionListener(this);
+            topBar.add(jLabel);
+            topBar.add(open);
+            topBar.add(refresh);
+
+            exportTablePanel.setLayout(new BorderLayout());
+            exportTablePanel.add(topBar, BorderLayout.NORTH);
+            exportTablePanel.add(jScrollPane);
+
+            exportTablePanel.setPreferredSize(new Dimension(800, 500));
+            JOptionPane pane = new JOptionPane(exportTablePanel, JOptionPane.PLAIN_MESSAGE, 0, null, new Object[] {"Close"});
+            exportTableDialog = pane.createDialog("VCell Exports");
+            exportTableDialog.setModal(false);
+            exportTableDialog.setResizable(true);
+            exportTableDialog.setVisible(true);
+        }
+        else {
+            exportTableDialog.setVisible(true);
+        }
+    }
+
+
 }
 


### PR DESCRIPTION
The ImageJ plugin now displays a cursor that signifies that the plugin is working to the user. Also refactored the code that loads the list of N5 datasets to use one thread object, and remove redundant code.